### PR TITLE
IA-6-Installer-for-desktop-application

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,6 +35,15 @@ jobs:
       - name: Run clean build with Maven
         run: mvn clean package
 
+      - name: Extract version from pom.xml file
+        id: version-extractor
+        uses: dostonhamrakulov/maven-artifact-version-extractor@v1.0
+        with:
+          file_path: ${{ github.workspace }}/pom.xml
+
+      - name: Project version
+        run: echo "Version ${{ steps.version-extractor.outputs.version }}"
+
       - name: Create package directory
         run: mkdir -p target/package
 
@@ -42,21 +51,18 @@ jobs:
         run: |
           jpackage --input target/ `
             --name InfirmaryApplication `
-            --main-jar infirmary-application-0.1.0.jar `
+            --main-jar "infirmary-application-${{ steps.version-extractor.outputs.version }}.jar" `
             --type exe `
             --dest target/package `
             --win-menu `
             --win-shortcut `
             --module-path "target/lib" `
             --add-modules javafx.controls,javafx.fxml,javafx.graphics,javafx.base `
-            --app-version 0.1.0 `
+            --app-version "${{ steps.version-extractor.outputs.version }}" `
             --vendor "RoCS" `
             --description "Infirmary Desktop Application" `
             --win-dir-chooser `
-            --win-menu-group "RoCS" `
-            --java-options "-Dapp.name=Infirmary Application" `
-            --java-options "-Dapp.version=0.1.0" `
-            --java-options "-Dorg.name=RoCS"
+            --verbose `
 
       - name: Upload the installer artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,66 @@
+name: Package and Create Artifact
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Java CI with Maven"]
+    branches: [ master ]
+    types: [ completed ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build-and-package:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Install WIX toolset
+        run: |
+          Invoke-WebRequest -Uri https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311.exe -OutFile wix311.exe
+          Start-Process -FilePath ".\wix311.exe" -ArgumentList "/install", "/quiet", "/norestart" -Wait
+          echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Run clean build with Maven
+        run: mvn clean package
+
+      - name: Create package directory
+        run: mkdir -p target/package
+
+      - name: Create JavaFX application installer artifact
+        run: |
+          jpackage --input target/ `
+            --name InfirmaryApplication `
+            --main-jar infirmary-application-0.1.0.jar `
+            --type exe `
+            --dest target/package `
+            --win-menu `
+            --win-shortcut `
+            --module-path "target/lib" `
+            --add-modules javafx.controls,javafx.fxml,javafx.graphics,javafx.base `
+            --app-version 0.1.0 `
+            --vendor "RoCS" `
+            --description "Infirmary Desktop Application" `
+            --win-dir-chooser `
+            --win-menu-group "RoCS" `
+            --java-options "-Dapp.name=Infirmary Application" `
+            --java-options "-Dapp.version=0.1.0" `
+            --java-options "-Dorg.name=RoCS"
+
+      - name: Upload the installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: InfirmaryApplication-Installer
+          path: target/package/InfirmaryApplication-*.exe
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.rocs</groupId>
     <artifactId>infirmary-application</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javafx.version>21</javafx.version>
+        <javafx.version>17.0.15</javafx.version>
 
         <system.module.path>com.rocs.infirmaryapplication</system.module.path>
         <main.class>com.rocs.infirmary.application.InfirmaryApplication</main.class>
@@ -138,15 +138,19 @@
                         <configuration>
                             <mainClass>${system.module.path}/${main.class}</mainClass>
                             <launcher>app</launcher>
-                            <jlinkZipName>app</jlinkZipName>
-                            <jlinkImageName>app</jlinkImageName>
                             <noManPages>true</noManPages>
                             <stripDebug>true</stripDebug>
                             <noHeaderFiles>true</noHeaderFiles>
                             <options>
                                 <option>--add-modules</option>
                                 <option>javafx.controls,javafx.fxml</option>
+                                <option>ALL-MODULE-PATH,java.sql</option>
+                                <option>--ignore-signing-information</option>
                             </options>
+
+                            <jlinkImageName>runtime</jlinkImageName>
+                            <jlinkZipName>runtime-zip</jlinkZipName>
+                            <jlinkVerbose>true</jlinkVerbose>
                         </configuration>
                     </execution>
                 </executions>
@@ -232,7 +236,7 @@
                 <executions>
                     <execution>
                         <id>generate-javadoc</id>
-                        <phase>package</phase>
+                        <phase>site</phase>
                         <goals>
                             <goal>javadoc</goal>
                         </goals>


### PR DESCRIPTION
Created a ci pipeline for packaging an installable app using jpackage and wix toolset, the implementation is currently still on static because of versioning

Changed JavaFX version to 17.0.15 and resolving the build warnings

Changed JavaDOC behavior, instead of running during package phase it will now run during site phase via mvn site. JavaDOC warnings causes issues to jpackage and wix toolset resulting on failed packaging